### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = ""

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # cpp-box
 
 
-
+[![Run on Repl.it](https://repl.it/badge/github/ehom/cpp-box)](https://repl.it/github/ehom/cpp-box)
 
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).